### PR TITLE
docs: ajouter la documentation Swagger/OpenAPI complète

### DIFF
--- a/app/Http/Controllers/SwaggerInfo.php
+++ b/app/Http/Controllers/SwaggerInfo.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+/**
+ * @OA\Info(
+ *     version="1.0.0",
+ *     title="MyBAD",
+ *     description="Application de gestion de tournois de badminton en milieu scolaire. Développée avec Laravel 12, Vue 3 et Inertia.js. Les routes Inertia retournent leurs props en JSON lors des requêtes XHR (header X-Inertia: true).",
+ *     @OA\Contact(name="Maël Sellier", email="selliermael@gmail.com")
+ * )
+ * @OA\Server(url="http://www.my-bad.local", description="Serveur local Laragon")
+ * @OA\SecurityScheme(
+ *     securityScheme="session",
+ *     type="apiKey",
+ *     in="cookie",
+ *     name="laravel_session",
+ *     description="Session Laravel (cookie HTTP-only)"
+ * )
+ * @OA\Tag(name="Auth Admin", description="Authentification des administrateurs")
+ * @OA\Tag(name="Admin - Tableau de bord", description="Tableau de bord et sélection de cours")
+ * @OA\Tag(name="Admin - Joueurs", description="Gestion des joueurs d'un cours")
+ * @OA\Tag(name="Admin - Matchs", description="Consultation et modification des matchs")
+ * @OA\Tag(name="Admin - Classement", description="Classement ELO de la classe")
+ * @OA\Tag(name="Admin - Règles", description="Paramètres ELO et règles des défis")
+ * @OA\Tag(name="Admin - Séance", description="Démarrage et clôture d'une séance")
+ * @OA\Tag(name="Admin - Compte", description="Gestion du profil administrateur")
+ * @OA\Tag(name="Admin - Administrateurs", description="Gestion des co-administrateurs")
+ * @OA\Tag(name="Auth Joueur", description="Authentification des joueurs")
+ * @OA\Tag(name="Joueur - Tableau de bord", description="Tableau de bord joueur")
+ * @OA\Tag(name="Joueur - Matchs", description="Déclaration et historique des matchs")
+ * @OA\Tag(name="Joueur - Classement", description="Classement ELO et historique")
+ * @OA\Tag(name="Joueur - Compte", description="Gestion du profil joueur")
+ */
+class SwaggerInfo {}

--- a/app/Http/Controllers/admin/AdminAccountController.php
+++ b/app/Http/Controllers/admin/AdminAccountController.php
@@ -15,6 +15,27 @@ use Inertia\Response;
 
 class AdminAccountController extends Controller
 {
+    /**
+     * @OA\Get(
+     *     path="/admin/account",
+     *     tags={"Admin - Compte"},
+     *     summary="Page du compte administrateur",
+     *     operationId="admin.account.index",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia de la page compte",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="user", type="object",
+     *                 @OA\Property(property="id", type="string", format="uuid"),
+     *                 @OA\Property(property="first_name", type="string"),
+     *                 @OA\Property(property="last_name", type="string"),
+     *                 @OA\Property(property="email", type="string", format="email")
+     *             )
+     *         )
+     *     )
+     * )
+     */
     public function index(): Response
     {
         /** @var User $user */
@@ -25,6 +46,26 @@ class AdminAccountController extends Controller
         ]);
     }
 
+    /**
+     * @OA\Put(
+     *     path="/admin/account/profile",
+     *     tags={"Admin - Compte"},
+     *     summary="Mettre à jour le profil administrateur",
+     *     operationId="admin.account.profile",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"first_name","last_name","email"},
+     *             @OA\Property(property="first_name", type="string", maxLength=255),
+     *             @OA\Property(property="last_name", type="string", maxLength=255),
+     *             @OA\Property(property="email", type="string", format="email", maxLength=255)
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Retour avec message de succès"),
+     *     @OA\Response(response=422, description="Email déjà utilisé ou données invalides")
+     * )
+     */
     public function updateProfile(Request $request): RedirectResponse
     {
         $request->validate([
@@ -45,6 +86,26 @@ class AdminAccountController extends Controller
         return back()->with('success', 'Profil mis à jour avec succès.');
     }
 
+    /**
+     * @OA\Put(
+     *     path="/admin/account/password",
+     *     tags={"Admin - Compte"},
+     *     summary="Changer le mot de passe administrateur",
+     *     operationId="admin.account.password",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"current_password","new_password","new_password_confirmation"},
+     *             @OA\Property(property="current_password", type="string", format="password"),
+     *             @OA\Property(property="new_password", type="string", format="password", minLength=8),
+     *             @OA\Property(property="new_password_confirmation", type="string", format="password")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Retour avec message de succès"),
+     *     @OA\Response(response=422, description="Mot de passe actuel incorrect")
+     * )
+     */
     public function updatePassword(Request $request): RedirectResponse
     {
         $request->validate([

--- a/app/Http/Controllers/admin/AdminAdminsController.php
+++ b/app/Http/Controllers/admin/AdminAdminsController.php
@@ -11,6 +11,34 @@ use Inertia\Response;
 
 class AdminAdminsController extends Controller
 {
+    /**
+     * @OA\Get(
+     *     path="/admin/administrateurs",
+     *     tags={"Admin - Administrateurs"},
+     *     summary="Liste des co-administrateurs des cours",
+     *     operationId="admin.admins.index",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia de la page administrateurs",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="admins", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="string", format="uuid"),
+     *                 @OA\Property(property="userId", type="string", format="uuid"),
+     *                 @OA\Property(property="name", type="string"),
+     *                 @OA\Property(property="email", type="string", format="email"),
+     *                 @OA\Property(property="avatar", type="string", nullable=true),
+     *                 @OA\Property(property="isPlayer", type="boolean"),
+     *                 @OA\Property(property="createdAt", type="string"),
+     *                 @OA\Property(property="classes", type="array", @OA\Items(type="object"))
+     *             )),
+     *             @OA\Property(property="adminCount", type="integer"),
+     *             @OA\Property(property="currentUserId", type="string", format="uuid")
+     *         )
+     *     ),
+     *     @OA\Response(response=403, description="Accès réservé aux admins purs (non-joueurs)")
+     * )
+     */
     public function index(): Response
     {
         $user = auth('admin')->user();
@@ -63,6 +91,18 @@ class AdminAdminsController extends Controller
     }
 
 
+    /**
+     * @OA\Delete(
+     *     path="/admin/administrateurs/{admin}",
+     *     tags={"Admin - Administrateurs"},
+     *     summary="Retirer un administrateur",
+     *     operationId="admin.admins.destroy",
+     *     security={{"session":{}}},
+     *     @OA\Parameter(name="admin", in="path", required=true, description="UUID de l'AdminUser", @OA\Schema(type="string", format="uuid")),
+     *     @OA\Response(response=302, description="Retour avec message de succès"),
+     *     @OA\Response(response=422, description="Impossible de se retirer soi-même")
+     * )
+     */
     public function destroy(AdminUser $admin): RedirectResponse
     {
         $currentUser = auth('admin')->user();

--- a/app/Http/Controllers/admin/AdminClassController.php
+++ b/app/Http/Controllers/admin/AdminClassController.php
@@ -17,11 +17,42 @@ use Inertia\Response;
 
 class AdminClassController extends Controller
 {
+    /**
+     * @OA\Get(
+     *     path="/admin/class/create",
+     *     tags={"Admin - Tableau de bord"},
+     *     summary="Formulaire de création d'un cours",
+     *     operationId="admin.class.create",
+     *     security={{"session":{}}},
+     *     @OA\Response(response=200, description="Page de création d'un cours")
+     * )
+     */
     public function create(): Response
     {
         return Inertia::render('Admin/Class/Create');
     }
 
+    /**
+     * @OA\Post(
+     *     path="/admin/class",
+     *     tags={"Admin - Tableau de bord"},
+     *     summary="Créer un nouveau cours",
+     *     operationId="admin.class.store",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"school_year","name"},
+     *             @OA\Property(property="school_year", type="string", maxLength=20, example="2024-2025"),
+     *             @OA\Property(property="name", type="string", maxLength=100, example="Terminale A"),
+     *             @OA\Property(property="address", type="string", nullable=true, maxLength=255),
+     *             @OA\Property(property="description", type="string", nullable=true, maxLength=1000)
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /admin/dashboard"),
+     *     @OA\Response(response=422, description="Données invalides")
+     * )
+     */
     public function store(Request $request): RedirectResponse
     {
         $validated = $request->validate([
@@ -60,6 +91,18 @@ class AdminClassController extends Controller
         return redirect()->route('admin.dashboard')->with('success', 'Cours créé avec succès.');
     }
 
+    /**
+     * @OA\Delete(
+     *     path="/admin/class/{class}",
+     *     tags={"Admin - Tableau de bord"},
+     *     summary="Supprimer un cours (cascade complète)",
+     *     operationId="admin.class.destroy",
+     *     security={{"session":{}}},
+     *     @OA\Parameter(name="class", in="path", required=true, description="ID du cours", @OA\Schema(type="integer")),
+     *     @OA\Response(response=302, description="Redirection vers /admin/dashboard"),
+     *     @OA\Response(response=403, description="Accès interdit")
+     * )
+     */
     public function destroy(SchoolClass $class): RedirectResponse
     {
         $adminUser = auth('admin')->user()->adminUser;

--- a/app/Http/Controllers/admin/AdminDashboardController.php
+++ b/app/Http/Controllers/admin/AdminDashboardController.php
@@ -18,6 +18,30 @@ class AdminDashboardController extends Controller
         private readonly RankingService $rankingService,
     ) {}
 
+    /**
+     * @OA\Get(
+     *     path="/admin/dashboard",
+     *     tags={"Admin - Tableau de bord"},
+     *     summary="Tableau de bord administrateur",
+     *     operationId="admin.dashboard",
+     *     security={{"session":{}}},
+     *     @OA\Parameter(name="period", in="query", required=false, description="Période de stats : '30j' ou 'all'", @OA\Schema(type="string", enum={"30j","all"}, default="30j")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia du tableau de bord",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="classes", type="array", @OA\Items(@OA\Property(property="id",type="integer"), @OA\Property(property="name",type="string"))),
+     *             @OA\Property(property="selectedClassId", type="integer", nullable=true),
+     *             @OA\Property(property="playerCount", type="integer"),
+     *             @OA\Property(property="matchCount", type="integer"),
+     *             @OA\Property(property="rankingPlayers", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="period", type="string"),
+     *             @OA\Property(property="hasActiveSession", type="boolean")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /admin/login si non authentifié")
+     * )
+     */
     public function index(Request $request): Response
     {
         $user = auth('admin')->user();
@@ -71,6 +95,24 @@ class AdminDashboardController extends Controller
         ]);
     }
 
+    /**
+     * @OA\Post(
+     *     path="/admin/class/select",
+     *     tags={"Admin - Tableau de bord"},
+     *     summary="Sélectionner le cours actif en session",
+     *     operationId="admin.class.select",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"class_id"},
+     *             @OA\Property(property="class_id", type="integer", example=1)
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers la page précédente"),
+     *     @OA\Response(response=403, description="Accès interdit à ce cours")
+     * )
+     */
     public function selectClass(Request $request): RedirectResponse
     {
         $request->validate(['class_id' => 'required|integer']);

--- a/app/Http/Controllers/admin/AdminMatchesController.php
+++ b/app/Http/Controllers/admin/AdminMatchesController.php
@@ -18,6 +18,36 @@ class AdminMatchesController extends Controller
 {
     public function __construct(private readonly EloService $eloService) {}
 
+    /**
+     * @OA\Get(
+     *     path="/admin/matchs",
+     *     tags={"Admin - Matchs"},
+     *     summary="Liste des matchs par séance",
+     *     operationId="admin.matches.index",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia de la page matchs",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="sessions", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="integer"),
+     *                 @OA\Property(property="date", type="string", format="date"),
+     *                 @OA\Property(property="match_count", type="integer"),
+     *                 @OA\Property(property="matches", type="array", @OA\Items(
+     *                     @OA\Property(property="id", type="integer"),
+     *                     @OA\Property(property="number", type="integer"),
+     *                     @OA\Property(property="player1", type="object"),
+     *                     @OA\Property(property="player2", type="object")
+     *                 ))
+     *             )),
+     *             @OA\Property(property="totalMatchCount", type="integer"),
+     *             @OA\Property(property="topMatchesPlayer", type="string", nullable=true),
+     *             @OA\Property(property="topWinsPlayer", type="string", nullable=true),
+     *             @OA\Property(property="selectedClass", type="object", nullable=true)
+     *         )
+     *     )
+     * )
+     */
     public function index(): Response
     {
         $user = Auth::guard('admin')->user();
@@ -126,6 +156,28 @@ class AdminMatchesController extends Controller
         ]);
     }
 
+    /**
+     * @OA\Put(
+     *     path="/admin/matchs/{gameMatch}",
+     *     tags={"Admin - Matchs"},
+     *     summary="Modifier les scores d'un match (recalcule l'ELO)",
+     *     operationId="admin.matches.update",
+     *     security={{"session":{}}},
+     *     @OA\Parameter(name="gameMatch", in="path", required=true, description="ID du match", @OA\Schema(type="integer")),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"player1_id","player2_id","score1","score2"},
+     *             @OA\Property(property="player1_id", type="integer"),
+     *             @OA\Property(property="player2_id", type="integer"),
+     *             @OA\Property(property="score1", type="integer", minimum=0, maximum=30),
+     *             @OA\Property(property="score2", type="integer", minimum=0, maximum=30)
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /admin/matchs"),
+     *     @OA\Response(response=422, description="Données invalides")
+     * )
+     */
     public function update(Request $request, GameMatch $gameMatch): RedirectResponse
     {
         $validated = $request->validate([
@@ -168,6 +220,17 @@ class AdminMatchesController extends Controller
         return redirect()->route('admin.matches')->with('success', 'Match mis à jour avec succès.');
     }
 
+    /**
+     * @OA\Delete(
+     *     path="/admin/matchs/{gameMatch}",
+     *     tags={"Admin - Matchs"},
+     *     summary="Supprimer un match (annule les ELO associés)",
+     *     operationId="admin.matches.destroy",
+     *     security={{"session":{}}},
+     *     @OA\Parameter(name="gameMatch", in="path", required=true, description="ID du match", @OA\Schema(type="integer")),
+     *     @OA\Response(response=302, description="Redirection vers /admin/matchs")
+     * )
+     */
     public function destroy(GameMatch $gameMatch): RedirectResponse
     {
         $schoolClassId = $gameMatch->classSession->school_class_id;

--- a/app/Http/Controllers/admin/AdminPlayersController.php
+++ b/app/Http/Controllers/admin/AdminPlayersController.php
@@ -22,6 +22,34 @@ class AdminPlayersController extends Controller
         private readonly RankingService $rankingService,
     ) {}
 
+    /**
+     * @OA\Get(
+     *     path="/admin/joueurs",
+     *     tags={"Admin - Joueurs"},
+     *     summary="Liste des joueurs du cours sélectionné",
+     *     operationId="admin.players.index",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia de la page joueurs",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="players", type="array", @OA\Items(type="object",
+     *                 @OA\Property(property="id", type="integer"),
+     *                 @OA\Property(property="name", type="string"),
+     *                 @OA\Property(property="elo", type="number"),
+     *                 @OA\Property(property="rank", type="integer"),
+     *                 @OA\Property(property="isActive", type="boolean")
+     *             )),
+     *             @OA\Property(property="playerCount", type="integer"),
+     *             @OA\Property(property="activePlayerCount", type="integer"),
+     *             @OA\Property(property="matchCount", type="integer"),
+     *             @OA\Property(property="averageElo", type="number"),
+     *             @OA\Property(property="classes", type="array", @OA\Items(@OA\Property(property="id",type="integer"),@OA\Property(property="name",type="string"))),
+     *             @OA\Property(property="selectedClassId", type="integer", nullable=true)
+     *         )
+     *     )
+     * )
+     */
     public function index(): Response
     {
         $user = auth('admin')->user();
@@ -76,6 +104,25 @@ class AdminPlayersController extends Controller
         ]);
     }
 
+    /**
+     * @OA\Post(
+     *     path="/admin/joueurs",
+     *     tags={"Admin - Joueurs"},
+     *     summary="Ajouter un joueur au cours via son code",
+     *     operationId="admin.players.store",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"code","elo"},
+     *             @OA\Property(property="code", type="string", minLength=6, maxLength=6, example="ABC123", description="Code unique du joueur"),
+     *             @OA\Property(property="elo", type="number", minimum=0, example=1000)
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /admin/joueurs"),
+     *     @OA\Response(response=422, description="Code inconnu ou joueur déjà dans le cours")
+     * )
+     */
     public function store(Request $request): RedirectResponse
     {
         $validated = $request->validate([
@@ -122,6 +169,28 @@ class AdminPlayersController extends Controller
         return redirect()->route('admin.players')->with('success', 'Joueur ajouté avec succès.');
     }
 
+    /**
+     * @OA\Put(
+     *     path="/admin/joueurs/{participant}",
+     *     tags={"Admin - Joueurs"},
+     *     summary="Modifier l'ELO et le statut d'un joueur",
+     *     operationId="admin.players.update",
+     *     security={{"session":{}}},
+     *     @OA\Parameter(name="participant", in="path", required=true, description="ID du ClassParticipant", @OA\Schema(type="integer")),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"elo","is_active"},
+     *             @OA\Property(property="elo", type="number", minimum=0, example=1050),
+     *             @OA\Property(property="is_active", type="boolean", example=true),
+     *             @OA\Property(property="make_admin", type="boolean", example=false),
+     *             @OA\Property(property="user_id", type="string", format="uuid")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /admin/joueurs"),
+     *     @OA\Response(response=422, description="Données invalides")
+     * )
+     */
     public function update(Request $request, ClassParticipant $participant): RedirectResponse
     {
         $validated = $request->validate([
@@ -191,6 +260,17 @@ class AdminPlayersController extends Controller
         return redirect()->route('admin.players')->with('success', 'Joueur mis à jour avec succès.');
     }
 
+    /**
+     * @OA\Delete(
+     *     path="/admin/joueurs/{participant}",
+     *     tags={"Admin - Joueurs"},
+     *     summary="Retirer un joueur du cours",
+     *     operationId="admin.players.destroy",
+     *     security={{"session":{}}},
+     *     @OA\Parameter(name="participant", in="path", required=true, description="ID du ClassParticipant", @OA\Schema(type="integer")),
+     *     @OA\Response(response=302, description="Redirection vers /admin/joueurs")
+     * )
+     */
     public function destroy(ClassParticipant $participant): RedirectResponse
     {
         $participant->eloHistories()->delete();

--- a/app/Http/Controllers/admin/AdminRankingController.php
+++ b/app/Http/Controllers/admin/AdminRankingController.php
@@ -20,6 +20,28 @@ class AdminRankingController extends Controller
     /*
      *  L'index va donner toutes les props initiales
      */
+    /**
+     * @OA\Get(
+     *     path="/admin/classement",
+     *     tags={"Admin - Classement"},
+     *     summary="Page classement ELO du cours",
+     *     operationId="admin.ranking.index",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia de la page classement",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="classes", type="array", @OA\Items(@OA\Property(property="id",type="integer"),@OA\Property(property="name",type="string"))),
+     *             @OA\Property(property="selectedClassId", type="integer", nullable=true),
+     *             @OA\Property(property="playerCount", type="integer"),
+     *             @OA\Property(property="rankingPlayers", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="enableRankingGroups", type="boolean"),
+     *             @OA\Property(property="enableEloHandicap", type="boolean"),
+     *             @OA\Property(property="groupSize", type="integer")
+     *         )
+     *     )
+     * )
+     */
     public function index(): Response
     {
         // Récuperation de l'admin
@@ -87,6 +109,26 @@ class AdminRankingController extends Controller
     /*
      * data() retourne une réponse JSON avec uniquement les
      * champs qui doivent être rafraîchis pour obtenir le classement dynamique
+     */
+    /**
+     * @OA\Get(
+     *     path="/admin/classement/data",
+     *     tags={"Admin - Classement"},
+     *     summary="Données JSON fraîches du classement (polling temps réel)",
+     *     operationId="admin.ranking.data",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Données du classement en JSON",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="playerCount", type="integer"),
+     *             @OA\Property(property="rankingPlayers", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="enableRankingGroups", type="boolean"),
+     *             @OA\Property(property="enableEloHandicap", type="boolean"),
+     *             @OA\Property(property="groupSize", type="integer")
+     *         )
+     *     )
+     * )
      */
     public function data(): JsonResponse
     {

--- a/app/Http/Controllers/admin/AdminRulesController.php
+++ b/app/Http/Controllers/admin/AdminRulesController.php
@@ -18,6 +18,35 @@ class AdminRulesController extends Controller
         private readonly RuleService $ruleService,
     ) {}
 
+    /**
+     * @OA\Get(
+     *     path="/admin/regles",
+     *     tags={"Admin - Règles"},
+     *     summary="Page de configuration des règles ELO",
+     *     operationId="admin.rules.index",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia de la page règles",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="classes", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="selectedClassId", type="integer", nullable=true),
+     *             @OA\Property(property="parameters", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="integer"),
+     *                 @OA\Property(property="minDiff", type="integer"),
+     *                 @OA\Property(property="maxDiff", type="integer"),
+     *                 @OA\Property(property="winnerPoints", type="number")
+     *             )),
+     *             @OA\Property(property="rule", type="object", nullable=true,
+     *                 @OA\Property(property="enableRankingGroups", type="boolean"),
+     *                 @OA\Property(property="enableEloHandicap", type="boolean"),
+     *                 @OA\Property(property="groupSize", type="integer"),
+     *                 @OA\Property(property="handicapParameters", type="array", @OA\Items(type="object"))
+     *             )
+     *         )
+     *     )
+     * )
+     */
     public function index(): Response
     {
         $user = auth('admin')->user();
@@ -80,6 +109,28 @@ class AdminRulesController extends Controller
         ]);
     }
 
+    /**
+     * @OA\Put(
+     *     path="/admin/regles",
+     *     tags={"Admin - Règles"},
+     *     summary="Mettre à jour les points ELO par tranche de différence",
+     *     operationId="admin.rules.update",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"parameters"},
+     *             @OA\Property(property="parameters", type="array", @OA\Items(
+     *                 required={"id","winner_points"},
+     *                 @OA\Property(property="id", type="integer"),
+     *                 @OA\Property(property="winner_points", type="number", example=0.5)
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /admin/regles"),
+     *     @OA\Response(response=422, description="Données invalides")
+     * )
+     */
     public function update(Request $request): RedirectResponse
     {
         $request->validate([
@@ -111,6 +162,24 @@ class AdminRulesController extends Controller
         return redirect()->route('admin.rules')->with('success', 'Règles enregistrées avec succès.');
     }
 
+    /**
+     * @OA\Put(
+     *     path="/admin/regles/defis",
+     *     tags={"Admin - Règles"},
+     *     summary="Mettre à jour les options de défis (groupes, handicap ELO)",
+     *     operationId="admin.rules.updateRule",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="enableRankingGroups", type="boolean"),
+     *             @OA\Property(property="enableEloHandicap", type="boolean"),
+     *             @OA\Property(property="groupSize", type="integer", minimum=2)
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /admin/regles")
+     * )
+     */
     public function updateRule(UpdateRuleRequest $request): RedirectResponse
     {
         $selectedClassId = session('admin_selected_class_id');

--- a/app/Http/Controllers/admin/AdminSessionController.php
+++ b/app/Http/Controllers/admin/AdminSessionController.php
@@ -17,6 +17,36 @@ class AdminSessionController extends Controller
         private readonly RankingService $rankingService,
     ) {}
 
+    /**
+     * @OA\Get(
+     *     path="/admin/session",
+     *     tags={"Admin - Séance"},
+     *     summary="Afficher la séance en cours (la crée si inexistante)",
+     *     operationId="admin.session.show",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia de la page séance",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="session", type="object",
+     *                 @OA\Property(property="id", type="integer"),
+     *                 @OA\Property(property="date", type="string", format="date-time"),
+     *                 @OA\Property(property="is_active", type="boolean")
+     *             ),
+     *             @OA\Property(property="rankingPlayers", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="playerCount", type="integer"),
+     *             @OA\Property(property="recentMatches", type="array", @OA\Items(
+     *                 @OA\Property(property="id", type="integer"),
+     *                 @OA\Property(property="player1", type="object"),
+     *                 @OA\Property(property="player2", type="object"),
+     *                 @OA\Property(property="winnerIndex", type="integer", nullable=true),
+     *                 @OA\Property(property="timeAgo", type="string")
+     *             ))
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /admin/dashboard si aucun cours sélectionné")
+     * )
+     */
     public function show(): Response|RedirectResponse
     {
         $adminUser = auth('admin')->user()->adminUser;
@@ -81,6 +111,16 @@ class AdminSessionController extends Controller
         ]);
     }
 
+    /**
+     * @OA\Post(
+     *     path="/admin/session",
+     *     tags={"Admin - Séance"},
+     *     summary="Démarrer une nouvelle séance",
+     *     operationId="admin.session.store",
+     *     security={{"session":{}}},
+     *     @OA\Response(response=302, description="Redirection vers /admin/session")
+     * )
+     */
     public function store(): RedirectResponse
     {
         $adminUser = auth('admin')->user()->adminUser;
@@ -120,6 +160,16 @@ class AdminSessionController extends Controller
         return redirect()->route('admin.session')->with('success', 'Séance lancée avec succès.');
     }
 
+    /**
+     * @OA\Post(
+     *     path="/admin/session/close",
+     *     tags={"Admin - Séance"},
+     *     summary="Clôturer la séance en cours",
+     *     operationId="admin.session.close",
+     *     security={{"session":{}}},
+     *     @OA\Response(response=302, description="Redirection vers /admin/dashboard")
+     * )
+     */
     public function close(): RedirectResponse
     {
         $adminUser = auth('admin')->user()->adminUser;

--- a/app/Http/Controllers/admin/Auth/AdminAuthenticatedSessionController.php
+++ b/app/Http/Controllers/admin/Auth/AdminAuthenticatedSessionController.php
@@ -14,7 +14,13 @@ use Inertia\Response;
 class AdminAuthenticatedSessionController extends Controller
 {
     /**
-     * Display the login view.
+     * @OA\Get(
+     *     path="/admin/login",
+     *     tags={"Auth Admin"},
+     *     summary="Page de connexion administrateur",
+     *     operationId="admin.login.form",
+     *     @OA\Response(response=200, description="Page de connexion rendue par Inertia")
+     * )
      */
     public function create(): Response
     {
@@ -24,7 +30,22 @@ class AdminAuthenticatedSessionController extends Controller
     }
 
     /**
-     * Handle an incoming authentication request.
+     * @OA\Post(
+     *     path="/admin/login",
+     *     tags={"Auth Admin"},
+     *     summary="Connexion administrateur",
+     *     operationId="admin.login.submit",
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"email","password"},
+     *             @OA\Property(property="email", type="string", format="email", example="admin@example.fr"),
+     *             @OA\Property(property="password", type="string", format="password", example="motdepasse123")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /admin/dashboard"),
+     *     @OA\Response(response=422, description="Identifiants incorrects ou compte non-admin")
+     * )
      */
     public function store(LoginRequest $request): RedirectResponse
     {
@@ -46,7 +67,14 @@ class AdminAuthenticatedSessionController extends Controller
     }
 
     /**
-     * Destroy an authenticated session.
+     * @OA\Post(
+     *     path="/admin/logout",
+     *     tags={"Auth Admin"},
+     *     summary="Déconnexion administrateur",
+     *     operationId="admin.logout",
+     *     security={{"session":{}}},
+     *     @OA\Response(response=302, description="Redirection vers /admin/login")
+     * )
      */
     public function destroy(Request $request): RedirectResponse
     {

--- a/app/Http/Controllers/admin/Auth/AdminPasswordResetController.php
+++ b/app/Http/Controllers/admin/Auth/AdminPasswordResetController.php
@@ -12,11 +12,37 @@ use Inertia\Inertia;
 
 class AdminPasswordResetController extends Controller
 {
+    /**
+     * @OA\Get(
+     *     path="/admin/forgot-password",
+     *     tags={"Auth Admin"},
+     *     summary="Afficher le formulaire mot de passe oublié (admin)",
+     *     operationId="admin.password.request",
+     *     @OA\Response(response=200, description="Page Inertia Admin/Auth/ForgotPassword")
+     * )
+     */
     public function showForgotForm()
     {
         return Inertia::render('Admin/Auth/ForgotPassword');
     }
 
+    /**
+     * @OA\Post(
+     *     path="/admin/forgot-password",
+     *     tags={"Auth Admin"},
+     *     summary="Envoyer le lien de réinitialisation à l'admin",
+     *     operationId="admin.password.email",
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"email"},
+     *             @OA\Property(property="email", type="string", format="email", example="admin@example.com")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection avec message de succès"),
+     *     @OA\Response(response=422, description="Email invalide ou introuvable")
+     * )
+     */
     public function sendResetLink(Request $request)
     {
         $request->validate([
@@ -34,6 +60,24 @@ class AdminPasswordResetController extends Controller
         return back()->withErrors(['email' => __($status)]);
     }
 
+    /**
+     * @OA\Get(
+     *     path="/admin/reset-password/{token}",
+     *     tags={"Auth Admin"},
+     *     summary="Afficher le formulaire de réinitialisation (admin)",
+     *     operationId="admin.password.reset",
+     *     @OA\Parameter(name="token", in="path", required=true, @OA\Schema(type="string")),
+     *     @OA\Parameter(name="email", in="query", required=false, @OA\Schema(type="string", format="email")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia du formulaire de réinitialisation admin",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="token", type="string"),
+     *             @OA\Property(property="email", type="string", nullable=true)
+     *         )
+     *     )
+     * )
+     */
     public function showResetForm(Request $request, string $token)
     {
         return Inertia::render('Admin/Auth/ResetPassword', [
@@ -42,6 +86,26 @@ class AdminPasswordResetController extends Controller
         ]);
     }
 
+    /**
+     * @OA\Post(
+     *     path="/admin/reset-password",
+     *     tags={"Auth Admin"},
+     *     summary="Réinitialiser le mot de passe de l'admin",
+     *     operationId="admin.password.update",
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"token","email","password","password_confirmation"},
+     *             @OA\Property(property="token", type="string"),
+     *             @OA\Property(property="email", type="string", format="email"),
+     *             @OA\Property(property="password", type="string", minLength=8),
+     *             @OA\Property(property="password_confirmation", type="string")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /admin/login après succès"),
+     *     @OA\Response(response=422, description="Token invalide ou email incorrect")
+     * )
+     */
     public function reset(Request $request)
     {
         $request->validate([

--- a/app/Http/Controllers/admin/Auth/RegisteredAdminController.php
+++ b/app/Http/Controllers/admin/Auth/RegisteredAdminController.php
@@ -12,6 +12,27 @@ use Illuminate\Support\Str;
 
 class RegisteredAdminController extends Controller
 {
+    /**
+     * @OA\Post(
+     *     path="/admin/register",
+     *     tags={"Auth Admin"},
+     *     summary="Inscription d'un nouvel administrateur",
+     *     operationId="admin.register",
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"first_name","last_name","email","password","password_confirmation"},
+     *             @OA\Property(property="first_name", type="string", maxLength=255, example="Marie"),
+     *             @OA\Property(property="last_name", type="string", maxLength=255, example="Dupont"),
+     *             @OA\Property(property="email", type="string", format="email", example="marie@example.fr"),
+     *             @OA\Property(property="password", type="string", format="password", minLength=8),
+     *             @OA\Property(property="password_confirmation", type="string", format="password")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /admin/dashboard"),
+     *     @OA\Response(response=422, description="Données invalides")
+     * )
+     */
     public function store(StoreAdminRequest $request): RedirectResponse
     {
         $validatedData = $request->validated();

--- a/app/Http/Controllers/player/AccountController.php
+++ b/app/Http/Controllers/player/AccountController.php
@@ -21,6 +21,16 @@ class AccountController extends Controller
 {
     public function __construct(private PlayerProfileService $profileService) {}
 
+    /**
+     * @OA\Get(
+     *     path="/joueur/profil",
+     *     tags={"Joueur - Compte"},
+     *     summary="Page de profil joueur",
+     *     operationId="player.account.index",
+     *     security={{"session":{}}},
+     *     @OA\Response(response=200, description="Props Inertia de la page profil")
+     * )
+     */
     public function index(): Response
     {
         /** @var User $user */
@@ -29,6 +39,27 @@ class AccountController extends Controller
         return Inertia::render('Player/Profile', $this->profileService->getProfileData($user));
     }
 
+    /**
+     * @OA\Get(
+     *     path="/joueur/profil/infos",
+     *     tags={"Joueur - Compte"},
+     *     summary="Informations personnelles du joueur",
+     *     operationId="player.account.infos",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia de la page informations personnelles",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="user", type="object",
+     *                 @OA\Property(property="id", type="string", format="uuid"),
+     *                 @OA\Property(property="first_name", type="string"),
+     *                 @OA\Property(property="last_name", type="string"),
+     *                 @OA\Property(property="email", type="string", format="email")
+     *             )
+     *         )
+     *     )
+     * )
+     */
     public function infos(): Response
     {
         /** @var User $user */
@@ -39,6 +70,25 @@ class AccountController extends Controller
         ]);
     }
 
+    /**
+     * @OA\Put(
+     *     path="/joueur/profil/infos",
+     *     tags={"Joueur - Compte"},
+     *     summary="Mettre à jour les informations personnelles",
+     *     operationId="player.account.update",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="first_name", type="string", maxLength=255),
+     *             @OA\Property(property="last_name", type="string", maxLength=255),
+     *             @OA\Property(property="email", type="string", format="email")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /joueur/profil/infos"),
+     *     @OA\Response(response=422, description="Données invalides")
+     * )
+     */
     public function update(UpdateProfileRequest $request): RedirectResponse
     {
         /** @var User $user */
@@ -49,6 +99,16 @@ class AccountController extends Controller
         return redirect()->route('player.account.infos');
     }
 
+    /**
+     * @OA\Get(
+     *     path="/joueur/profil/confidentialite",
+     *     tags={"Joueur - Compte"},
+     *     summary="Page confidentialité avec résumé des données personnelles",
+     *     operationId="player.account.privacy",
+     *     security={{"session":{}}},
+     *     @OA\Response(response=200, description="Résumé des données personnelles")
+     * )
+     */
     public function privacy(PlayerExportService $export): Response
     {
         /** @var User $user */
@@ -57,6 +117,20 @@ class AccountController extends Controller
         return Inertia::render('Player/Privacy', $export->summary($user));
     }
 
+    /**
+     * @OA\Get(
+     *     path="/joueur/profil/download",
+     *     tags={"Joueur - Compte"},
+     *     summary="Télécharger ses données personnelles (JSON)",
+     *     operationId="player.account.download",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Export JSON des données du joueur (Content-Disposition: attachment)",
+     *         @OA\JsonContent(type="object")
+     *     )
+     * )
+     */
     public function download(PlayerExportService $export): JsonResponse
     {
         /** @var User $user */
@@ -67,6 +141,23 @@ class AccountController extends Controller
         ]);
     }
 
+    /**
+     * @OA\Post(
+     *     path="/joueur/classe",
+     *     tags={"Joueur - Compte"},
+     *     summary="Sélectionner la classe active du joueur",
+     *     operationId="player.class.select",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"class_id"},
+     *             @OA\Property(property="class_id", type="integer")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Retour vers la page précédente")
+     * )
+     */
     public function selectClass(SelectClassRequest $request): RedirectResponse
     {
         $player = auth('player')->user()->player;
@@ -78,6 +169,16 @@ class AccountController extends Controller
         return redirect()->back();
     }
 
+    /**
+     * @OA\Delete(
+     *     path="/joueur/profil",
+     *     tags={"Joueur - Compte"},
+     *     summary="Supprimer son compte joueur",
+     *     operationId="player.account.destroy",
+     *     security={{"session":{}}},
+     *     @OA\Response(response=302, description="Redirection vers /player/login")
+     * )
+     */
     public function destroy(DeleteAccountRequest $request): RedirectResponse
     {
         /** @var User $user */
@@ -92,6 +193,27 @@ class AccountController extends Controller
         return redirect()->route('player.login');
     }
 
+    /**
+     * @OA\Post(
+     *     path="/joueur/profil/photo",
+     *     tags={"Joueur - Compte"},
+     *     summary="Mettre à jour la photo de profil",
+     *     operationId="player.account.photo",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\MediaType(
+     *             mediaType="multipart/form-data",
+     *             @OA\Schema(
+     *                 required={"photo"},
+     *                 @OA\Property(property="photo", type="string", format="binary", description="Fichier image (jpg/png/gif, max 2Mo)")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Retour vers la page précédente"),
+     *     @OA\Response(response=422, description="Fichier invalide")
+     * )
+     */
     public function updatePhoto(UpdatePhotoRequest $request): RedirectResponse
     {
         /** @var User $user */

--- a/app/Http/Controllers/player/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/player/Auth/AuthenticatedSessionController.php
@@ -14,7 +14,13 @@ use Inertia\Response;
 class AuthenticatedSessionController extends Controller
 {
     /**
-     * Display the login view.
+     * @OA\Get(
+     *     path="/player/login",
+     *     tags={"Auth Joueur"},
+     *     summary="Page de connexion joueur",
+     *     operationId="player.login.form",
+     *     @OA\Response(response=200, description="Page de connexion rendue par Inertia")
+     * )
      */
     public function create(): Response
     {
@@ -24,7 +30,22 @@ class AuthenticatedSessionController extends Controller
     }
 
     /**
-     * Handle an incoming authentication request.
+     * @OA\Post(
+     *     path="/player/login",
+     *     tags={"Auth Joueur"},
+     *     summary="Connexion joueur",
+     *     operationId="player.login.submit",
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"email","password"},
+     *             @OA\Property(property="email", type="string", format="email", example="joueur@example.fr"),
+     *             @OA\Property(property="password", type="string", format="password")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /"),
+     *     @OA\Response(response=422, description="Identifiants incorrects ou compte non associé à un joueur")
+     * )
      */
     public function store(LoginRequest $request): RedirectResponse
     {
@@ -46,7 +67,14 @@ class AuthenticatedSessionController extends Controller
     }
 
     /**
-     * Destroy an authenticated session.
+     * @OA\Post(
+     *     path="/joueur/profil/logout",
+     *     tags={"Auth Joueur"},
+     *     summary="Déconnexion joueur",
+     *     operationId="player.logout",
+     *     security={{"session":{}}},
+     *     @OA\Response(response=302, description="Redirection vers /player/login")
+     * )
      */
     public function destroy(Request $request): RedirectResponse
     {

--- a/app/Http/Controllers/player/Auth/GoogleAuthController.php
+++ b/app/Http/Controllers/player/Auth/GoogleAuthController.php
@@ -13,11 +13,31 @@ use Laravel\Socialite\Two\InvalidStateException;
 
 class GoogleAuthController extends Controller
 {
+    /**
+     * @OA\Get(
+     *     path="/player/auth/google/redirect",
+     *     tags={"Auth Joueur"},
+     *     summary="Redirection vers Google OAuth",
+     *     operationId="player.google.redirect",
+     *     @OA\Response(response=302, description="Redirection vers l'URL d'autorisation Google")
+     * )
+     */
     public function redirect(): RedirectResponse
     {
         return Socialite::driver('google')->redirect();
     }
 
+    /**
+     * @OA\Get(
+     *     path="/player/auth/google/callback",
+     *     tags={"Auth Joueur"},
+     *     summary="Callback Google OAuth — connexion ou création du joueur",
+     *     operationId="player.google.callback",
+     *     @OA\Parameter(name="code", in="query", required=false, description="Code OAuth2 Google", @OA\Schema(type="string")),
+     *     @OA\Parameter(name="error", in="query", required=false, description="Erreur retournée par Google", @OA\Schema(type="string")),
+     *     @OA\Response(response=302, description="Redirection vers / (succès) ou /player/login (erreur ou annulation)")
+     * )
+     */
     public function callback(): RedirectResponse
     {
         if (request()->has('error')) {

--- a/app/Http/Controllers/player/Auth/PasswordResetController.php
+++ b/app/Http/Controllers/player/Auth/PasswordResetController.php
@@ -13,7 +13,21 @@ use Inertia\Inertia;
 class PasswordResetController extends Controller
 {
     /**
-     * Envoyer le lien de réinitialisation par email.
+     * @OA\Post(
+     *     path="/player/auth/mot-de-passe-oublie",
+     *     tags={"Auth Joueur"},
+     *     summary="Envoyer le lien de réinitialisation de mot de passe",
+     *     operationId="player.password.email",
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"email"},
+     *             @OA\Property(property="email", type="string", format="email", example="joueur@example.com")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection avec message de succès"),
+     *     @OA\Response(response=422, description="Email invalide ou introuvable")
+     * )
      */
     public function sendResetLink(Request $request)
     {
@@ -33,7 +47,22 @@ class PasswordResetController extends Controller
     }
 
     /**
-     * Afficher le formulaire de réinitialisation.
+     * @OA\Get(
+     *     path="/player/auth/reset-password/{token}",
+     *     tags={"Auth Joueur"},
+     *     summary="Afficher le formulaire de réinitialisation de mot de passe",
+     *     operationId="player.password.reset",
+     *     @OA\Parameter(name="token", in="path", required=true, @OA\Schema(type="string")),
+     *     @OA\Parameter(name="email", in="query", required=false, @OA\Schema(type="string", format="email")),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia du formulaire de réinitialisation",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="token", type="string"),
+     *             @OA\Property(property="email", type="string", nullable=true)
+     *         )
+     *     )
+     * )
      */
     public function showResetForm(Request $request, string $token)
     {
@@ -44,7 +73,24 @@ class PasswordResetController extends Controller
     }
 
     /**
-     * Réinitialiser le mot de passe.
+     * @OA\Post(
+     *     path="/player/auth/reset-password",
+     *     tags={"Auth Joueur"},
+     *     summary="Réinitialiser le mot de passe du joueur",
+     *     operationId="player.password.update",
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"token","email","password","password_confirmation"},
+     *             @OA\Property(property="token", type="string"),
+     *             @OA\Property(property="email", type="string", format="email"),
+     *             @OA\Property(property="password", type="string", minLength=8),
+     *             @OA\Property(property="password_confirmation", type="string")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /player/login après succès"),
+     *     @OA\Response(response=422, description="Token invalide ou email incorrect")
+     * )
      */
     public function reset(Request $request)
     {

--- a/app/Http/Controllers/player/Auth/RegisteredPlayerController.php
+++ b/app/Http/Controllers/player/Auth/RegisteredPlayerController.php
@@ -13,6 +13,27 @@ use Illuminate\Support\Str;
 class RegisteredPlayerController extends Controller
 {
 
+    /**
+     * @OA\Post(
+     *     path="/player/register",
+     *     tags={"Auth Joueur"},
+     *     summary="Inscription d'un nouveau joueur",
+     *     operationId="player.register",
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"first_name","last_name","email","password","password_confirmation"},
+     *             @OA\Property(property="first_name", type="string", maxLength=255, example="Léa"),
+     *             @OA\Property(property="last_name", type="string", maxLength=255, example="Martin"),
+     *             @OA\Property(property="email", type="string", format="email", example="lea@example.fr"),
+     *             @OA\Property(property="password", type="string", format="password", minLength=8),
+     *             @OA\Property(property="password_confirmation", type="string", format="password")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /"),
+     *     @OA\Response(response=422, description="Données invalides ou email déjà utilisé")
+     * )
+     */
     public function store(StorePlayerRequest $request): RedirectResponse
     {
         $validatedData = $request->validated();

--- a/app/Http/Controllers/player/DashboardController.php
+++ b/app/Http/Controllers/player/DashboardController.php
@@ -15,6 +15,23 @@ class DashboardController extends Controller
         private readonly RankingService $rankingService,
     ) {}
 
+    /**
+     * @OA\Get(
+     *     path="/",
+     *     tags={"Joueur - Tableau de bord"},
+     *     summary="Tableau de bord joueur",
+     *     operationId="player.dashboard",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia du tableau de bord joueur",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="rankingPlayers", type="array", @OA\Items(type="object"))
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Redirection vers /player/login si non authentifié")
+     * )
+     */
     public function index(): Response
     {
         $user    = auth('player')->user();

--- a/app/Http/Controllers/player/EloDetailsController.php
+++ b/app/Http/Controllers/player/EloDetailsController.php
@@ -16,6 +16,23 @@ class EloDetailsController extends Controller
         private readonly PlayerProfileService $profileService,
     ) {}
 
+    /**
+     * @OA\Get(
+     *     path="/elo-details",
+     *     tags={"Joueur - Classement"},
+     *     summary="Historique ELO détaillé du joueur",
+     *     operationId="player.elo.details",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia de la page détail ELO",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="classes", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="selectedClassId", type="integer", nullable=true)
+     *         )
+     *     )
+     * )
+     */
     public function index(): Response
     {
         $user          = Auth::guard('player')->user();

--- a/app/Http/Controllers/player/MatchDeclarationController.php
+++ b/app/Http/Controllers/player/MatchDeclarationController.php
@@ -20,7 +20,21 @@ class MatchDeclarationController extends Controller
     ) {}
 
     /**
-     * Affiche la page de déclaration de match.
+     * @OA\Get(
+     *     path="/declarer-un-match",
+     *     tags={"Joueur - Matchs"},
+     *     summary="Page de déclaration de match",
+     *     operationId="player.match.declare",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia de la page déclaration",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="currentPlayer", type="object"),
+     *             @OA\Property(property="activeSession", type="integer", nullable=true, description="ID de la séance active")
+     *         )
+     *     )
+     * )
      */
     public function create(): Response
     {
@@ -33,7 +47,22 @@ class MatchDeclarationController extends Controller
     }
 
     /**
-     * Retourne la liste des adversaires disponibles pour la séance active.
+     * @OA\Get(
+     *     path="/declarer-un-match/adversaires",
+     *     tags={"Joueur - Matchs"},
+     *     summary="Liste des adversaires disponibles dans la séance active",
+     *     operationId="player.match.opponents",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Liste des adversaires et ELO courant du joueur",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="opponents", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="currentElo", type="number"),
+     *             @OA\Property(property="error", type="string", nullable=true, description="Message d'erreur si aucune séance active")
+     *         )
+     *     )
+     * )
      */
     public function opponents(): JsonResponse
     {
@@ -51,7 +80,30 @@ class MatchDeclarationController extends Controller
     }
 
     /**
-     * Vérifie le PIN de l'adversaire.
+     * @OA\Post(
+     *     path="/declarer-un-match/verify-pin",
+     *     tags={"Joueur - Matchs"},
+     *     summary="Vérifier le PIN de l'adversaire",
+     *     operationId="player.match.verifyPin",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"player_id","pin"},
+     *             @OA\Property(property="player_id", type="integer", description="ID du joueur adverse"),
+     *             @OA\Property(property="pin", type="string", minLength=4, maxLength=4, example="1234")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Résultat de la vérification",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="valid", type="boolean"),
+     *             @OA\Property(property="message", type="string", nullable=true)
+     *         )
+     *     ),
+     *     @OA\Response(response=422, description="Données invalides")
+     * )
      */
     public function verifyPin(VerifyPinRequest $request): JsonResponse
     {
@@ -61,7 +113,35 @@ class MatchDeclarationController extends Controller
     }
 
     /**
-     * Enregistre le match en base de données.
+     * @OA\Post(
+     *     path="/declarer-un-match",
+     *     tags={"Joueur - Matchs"},
+     *     summary="Enregistrer un match et recalculer les ELO",
+     *     operationId="player.match.store",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"opponent_id","my_score","opponent_score"},
+     *             @OA\Property(property="opponent_id", type="integer"),
+     *             @OA\Property(property="my_score", type="integer", minimum=0, maximum=21, example=15),
+     *             @OA\Property(property="opponent_score", type="integer", minimum=0, maximum=21, example=10,
+     *                 description="Au moins un des deux scores doit être ≥ 15"
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Match enregistré avec succès",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(property="eloChange", type="number", description="Variation d'ELO du joueur courant"),
+     *             @OA\Property(property="eloChangeOpponent", type="number"),
+     *             @OA\Property(property="match_id", type="integer")
+     *         )
+     *     ),
+     *     @OA\Response(response=422, description="Aucune séance active, déjà joué contre cet adversaire, ou scores invalides")
+     * )
      */
     public function store(StoreMatchRequest $request): JsonResponse
     {

--- a/app/Http/Controllers/player/MatchHistoryController.php
+++ b/app/Http/Controllers/player/MatchHistoryController.php
@@ -16,6 +16,24 @@ class MatchHistoryController extends Controller
         private readonly PlayerProfileService $profileService,
     ) {}
 
+    /**
+     * @OA\Get(
+     *     path="/historique-matchs",
+     *     tags={"Joueur - Matchs"},
+     *     summary="Historique des matchs du joueur",
+     *     operationId="player.matches.history",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia de la page historique",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="matches", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="classes", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="selectedClassId", type="integer", nullable=true)
+     *         )
+     *     )
+     * )
+     */
     public function index(): Response
     {
         $player  = Auth::guard('player')->user()->player;

--- a/app/Http/Controllers/player/PinController.php
+++ b/app/Http/Controllers/player/PinController.php
@@ -12,6 +12,24 @@ class PinController extends Controller
 {
     public function __construct(private readonly PlayerProfileService $profileService) {}
 
+    /**
+     * @OA\Post(
+     *     path="/joueur/pin",
+     *     tags={"Joueur - Compte"},
+     *     summary="Définir ou modifier le PIN du joueur",
+     *     operationId="player.pin.store",
+     *     security={{"session":{}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"pin"},
+     *             @OA\Property(property="pin", type="string", minLength=4, maxLength=4, pattern="^\\d{4}$", example="1234", description="Code PIN à 4 chiffres")
+     *         )
+     *     ),
+     *     @OA\Response(response=302, description="Retour vers la page précédente"),
+     *     @OA\Response(response=422, description="Le PIN doit être 4 chiffres")
+     * )
+     */
     public function store(StorePinRequest $request): RedirectResponse
     {
         $this->profileService->setPin(Auth::guard('player')->user()->player, $request->pin);

--- a/app/Http/Controllers/player/RankingController.php
+++ b/app/Http/Controllers/player/RankingController.php
@@ -16,6 +16,24 @@ class RankingController extends Controller
         private readonly PlayerProfileService $profileService,
     ) {}
 
+    /**
+     * @OA\Get(
+     *     path="/classements",
+     *     tags={"Joueur - Classement"},
+     *     summary="Classement ELO du cours du joueur",
+     *     operationId="player.ranking",
+     *     security={{"session":{}}},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Props Inertia de la page classement",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="players", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="classes", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="selectedClassId", type="integer", nullable=true)
+     *         )
+     *     )
+     * )
+     */
     public function index(): Response
     {
         $user    = Auth::guard('player')->user();

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,8 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "darkaonline/l5-swagger": "^11.0",
+        "doctrine/annotations": "^2.0",
         "garygreen/pretty-routes": "^1.0",
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b8d058010864bc71728c8d9216f3157",
+    "content-hash": "f1ac23a7a83ae10b907b3623d9206ecb",
     "packages": [
         {
             "name": "brick/math",
@@ -136,6 +136,86 @@
             "time": "2024-02-09T16:56:22+00:00"
         },
         {
+            "name": "darkaonline/l5-swagger",
+            "version": "11.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "63d737e841533cac6e8c04a007561aa833f69f3a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/63d737e841533cac6e8c04a007561aa833f69f3a",
+                "reference": "63d737e841533cac6e8c04a007561aa833f69f3a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "laravel/framework": "^13.0 || ^12.1 || ^11.44",
+                "php": "^8.2",
+                "swagger-api/swagger-ui": ">=5.18.3",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "zircote/swagger-php": "^6.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "1.*",
+                "orchestra/testbench": "^11.0 || ^10.0 || ^9.0 || ^8.0 || 7.* || ^6.15 || 5.*",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+                    },
+                    "providers": [
+                        "L5Swagger\\L5SwaggerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "OpenApi or Swagger integration to Laravel",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/DarkaOnLine/L5-Swagger/issues",
+                "source": "https://github.com/DarkaOnLine/L5-Swagger/tree/11.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DarkaOnLine",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-08T13:14:00+00:00"
+        },
+        {
             "name": "dflydev/dot-access-data",
             "version": "v3.0.3",
             "source": {
@@ -209,6 +289,83 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2 || ^3",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.10.28",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^5.4 || ^6.4 || ^7",
+                "vimeo/psalm": "^4.30 || ^5.14"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
+            },
+            "abandoned": true,
+            "time": "2024-09-05T10:17:24+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -3230,6 +3387,102 @@
             "time": "2026-03-19T02:57:58+00:00"
         },
         {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
             "name": "psr/clock",
             "version": "1.0.0",
             "source": {
@@ -3721,6 +3974,68 @@
             "time": "2026-03-06T21:21:28+00:00"
         },
         {
+            "name": "radebatz/type-info-extras",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DerManoMann/type-info-extras.git",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DerManoMann/type-info-extras/zipball/95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "symfony/type-info": "^7.3.8 || ^7.4.1 || ^8.0 || ^8.1-@dev"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.70",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Radebatz\\TypeInfoExtras\\": "src"
+                },
+                "exclude-from-classmap": [
+                    "/tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.org"
+                }
+            ],
+            "description": "Extras for symfony/type-info",
+            "homepage": "http://radebatz.net/mano/",
+            "keywords": [
+                "component",
+                "symfony",
+                "type-info",
+                "types"
+            ],
+            "support": {
+                "issues": "https://github.com/DerManoMann/type-info-extras/issues",
+                "source": "https://github.com/DerManoMann/type-info-extras/tree/1.0.7"
+            },
+            "time": "2026-03-06T22:40:29+00:00"
+        },
+        {
             "name": "ralouphie/getallheaders",
             "version": "3.0.3",
             "source": {
@@ -3917,6 +4232,67 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
             "time": "2025-12-14T04:43:48+00:00"
+        },
+        {
+            "name": "swagger-api/swagger-ui",
+            "version": "v5.32.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swagger-api/swagger-ui.git",
+                "reference": "34d6186846b6b8a72024d43521efd71087203b08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/34d6186846b6b8a72024d43521efd71087203b08",
+                "reference": "34d6186846b6b8a72024d43521efd71087203b08",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Anna Bodnia",
+                    "email": "anna.bodnia@gmail.com"
+                },
+                {
+                    "name": "Buu Nguyen",
+                    "email": "buunguyen@gmail.com"
+                },
+                {
+                    "name": "Josh Ponelat",
+                    "email": "jponelat@gmail.com"
+                },
+                {
+                    "name": "Kyle Shockey",
+                    "email": "kyleshockey1@gmail.com"
+                },
+                {
+                    "name": "Robert Barnwell",
+                    "email": "robert@robertismy.name"
+                },
+                {
+                    "name": "Sahar Jafari",
+                    "email": "shr.jafari@gmail.com"
+                }
+            ],
+            "description": " Swagger UI is a collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API.",
+            "homepage": "http://swagger.io",
+            "keywords": [
+                "api",
+                "documentation",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/swagger-api/swagger-ui/issues",
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.32.4"
+            },
+            "time": "2026-04-15T09:05:22+00:00"
         },
         {
             "name": "symfony/clock",
@@ -6255,6 +6631,89 @@
             "time": "2025-07-15T13:41:35+00:00"
         },
         {
+            "name": "symfony/type-info",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/type-info.git",
+                "reference": "6bf34da885ff5143a3dfd8f1b863bb8ab95f50bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/6bf34da885ff5143a3dfd8f1b863bb8ab95f50bd",
+                "reference": "6bf34da885ff5143a3dfd8f1b863bb8ab95f50bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.30"
+            },
+            "require-dev": {
+                "phpstan/phpdoc-parser": "^1.30|^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\TypeInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Arlaud",
+                    "email": "mathias.arlaud@gmail.com"
+                },
+                {
+                    "name": "Baptiste LEDUC",
+                    "email": "baptiste.leduc@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts PHP types information.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "PHPStan",
+                "phpdoc",
+                "symfony",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/type-info/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
             "name": "symfony/uid",
             "version": "v7.4.4",
             "source": {
@@ -6418,6 +6877,82 @@
                 }
             ],
             "time": "2026-02-15T10:53:20+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.4.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/58751048de17bae71c5aa0d13cb19d79bca26391",
+                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.4.6"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-09T09:33:46+00:00"
         },
         {
             "name": "tightenco/ziggy",
@@ -6701,6 +7236,96 @@
                 }
             ],
             "time": "2024-11-21T01:49:47+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "6.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "2cc71771759d9fdfecd5fbb72bcb00e307f43ecb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/2cc71771759d9fdfecd5fbb72bcb00e307f43ecb",
+                "reference": "2cc71771759d9fdfecd5fbb72bcb00e307f43ecb",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.19 || ^5.0",
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "radebatz/type-info-extras": "^1.0.2",
+                "symfony/console": "^7.4 || ^8.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "symfony/process": ">=6, <6.4.14"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.62.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5 || >=12.5.22",
+                "rector/rector": "^2.3.1"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "Generate interactive documentation for your RESTful API using PHP attributes (preferred) or PHPDoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/6.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zircote",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-19T21:47:30+00:00"
         }
     ],
     "packages-dev": [
@@ -9436,82 +10061,6 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v7.4.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/58751048de17bae71c5aa0d13cb19d79bca26391",
-                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<6.4"
-            },
-            "require-dev": {
-                "symfony/console": "^6.4|^7.0|^8.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.6"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-02-09T09:33:46+00:00"
-        },
-        {
             "name": "theseer/tokenizer",
             "version": "1.3.1",
             "source": {
@@ -9571,5 +10120,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -1,0 +1,321 @@
+<?php
+
+return [
+    'default' => 'default',
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => 'L5 Swagger UI',
+            ],
+
+            'routes' => [
+                /*
+                 * Route for accessing api documentation interface
+                 */
+                'api' => 'api/documentation',
+            ],
+            'paths' => [
+                /*
+                 * Edit to include full URL in ui for assets
+                 */
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+
+                /*
+                * Edit to set path where swagger ui assets should be stored
+                */
+                'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+                /*
+                 * File name of the generated json documentation file
+                 */
+                'docs_json' => 'api-docs.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                 */
+                'docs_yaml' => 'api-docs.yaml',
+
+                /*
+                 * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                 */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                 */
+                'annotations' => [
+                    base_path('app'),
+                ],
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+             */
+            'docs' => 'docs',
+
+            /*
+             * Route for Oauth2 authentication callback.
+             */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+             */
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+             */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            /*
+             * Absolute path to location where parsed annotations will be stored
+             */
+            'docs' => storage_path('api-docs'),
+
+            /*
+             * Absolute path to directory where to export views
+             */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+             */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+             */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /**
+             * Configuration for default processors. Allows to pass processors configuration to swagger-php.
+             *
+             * @link https://zircote.github.io/swagger-php/reference/processors.html
+             */
+            'default_processors_configuration' => [
+            /** Example */
+            /**
+             * 'operationId.hash' => true,
+             * 'pathFilter' => [
+             * 'tags' => [
+             * '/pets/',
+             * '/store/',
+             * ],
+             * ],.
+             */
+            ],
+
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             *
+             * @see \OpenApi\scan
+             */
+            'analyser' => new \OpenApi\Analysers\ReflectionAnalyser([
+                new \OpenApi\Analysers\DocBlockAnnotationFactory(),
+                new \OpenApi\Analysers\AttributeAnnotationFactory(),
+            ]),
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis .
+             *
+             * @see \OpenApi\scan
+             */
+            'analysis' => null,
+
+            /**
+             * Custom query path processors classes.
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
+             * @see \OpenApi\scan
+             */
+            'processors' => [
+                // new \App\SwaggerProcessors\SchemaQueryParameter(),
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             *
+             * @see \OpenApi\scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+             */
+            'exclude' => [],
+
+            /*
+             * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
+             * By default the spec will be in version 3.0.0
+             */
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', \L5Swagger\Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [
+                /*
+                 * Examples of Security schemes
+                 */
+                /*
+                'api_key_security_example' => [ // Unique name of security
+                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for security scheme',
+                    'name' => 'api_key', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                'oauth2_security_example' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for oauth2 security scheme.',
+                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
+                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
+                    'scopes' => [
+                        'read:projects' => 'read your projects',
+                        'write:projects' => 'modify projects in your account',
+                    ]
+                ],
+                */
+
+                /* Open API 3.0 support
+                'passport' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Laravel passport oauth2 security.',
+                    'in' => 'header',
+                    'scheme' => 'https',
+                    'flows' => [
+                        "password" => [
+                            "authorizationUrl" => config('app.url') . '/oauth/authorize',
+                            "tokenUrl" => config('app.url') . '/oauth/token',
+                            "refreshUrl" => config('app.url') . '/token/refresh',
+                            "scopes" => []
+                        ],
+                    ],
+                ],
+                'sanctum' => [ // Unique name of security
+                    'type' => 'apiKey', // Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Enter token in format (Bearer <token>)',
+                    'name' => 'Authorization', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                */
+            ],
+            'security' => [
+                /*
+                 * Examples of Securities
+                 */
+                [
+                    /*
+                    'oauth2_security_example' => [
+                        'read',
+                        'write'
+                    ],
+
+                    'passport' => []
+                    */
+                ],
+            ],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+         */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', false),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+         */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', false),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+         */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+         */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+         */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+         */
+        'validator_url' => null,
+
+        /*
+         * Swagger UI configuration parameters
+         */
+        'ui' => [
+            'display' => [
+                'dark_mode' => env('L5_SWAGGER_UI_DARK_MODE', false),
+                /*
+                 * Controls the default expansion setting for the operations and tags. It can be :
+                 * 'list' (expands only the tags),
+                 * 'full' (expands the tags and operations),
+                 * 'none' (expands nothing).
+                 */
+                'doc_expansion' => env('L5_SWAGGER_UI_DOC_EXPANSION', 'none'),
+
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that
+                 * you can use to filter the tagged operations that are shown. Can be
+                 * Boolean to enable or disable, or a string, in which case filtering
+                 * will be enabled using that string as the filter expression. Filtering
+                 * is case-sensitive matching the filter expression anywhere inside
+                 * the tag.
+                 */
+                'filter' => env('L5_SWAGGER_UI_FILTERS', true), // true | false
+            ],
+
+            'authorization' => [
+                /*
+                 * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
+                 */
+                'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                'oauth2' => [
+                    /*
+                     * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                     */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
+            ],
+        ],
+        /*
+         * Constants which can be used in annotations
+         */
+        'constants' => [
+            'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+        ],
+    ],
+];


### PR DESCRIPTION
- Annoter tous les controllers (admin et joueur) avec @OA
- Créer SwaggerInfo.php pour les métadonnées globales (Info, Server, Tags, SecurityScheme)
- Configurer l5-swagger pour utiliser DocBlockAnnotationFactory (compatibilité annotations docblock avec swagger-php 6.x / l5-swagger 11.x)
- Ajouter doctrine/annotations comme dépendance requise
- Documenter les routes manquantes : PasswordReset, AdminPasswordReset, GoogleAuth